### PR TITLE
enable tasklist

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -5,3 +5,6 @@ theme:
   palette:
     scheme: slate
     primary: orange
+markdown_extensions:
+- pymdownx.tasklist:
+    custom_checkbox: true


### PR DESCRIPTION
hi, this should (hopefully) enable the tasklist extension, as per https://squidfunk.github.io/mkdocs-material/setup/extensions/python-markdown-extensions/#tasklist . cheers